### PR TITLE
allow printing floats. add LibC.memchr

### DIFF
--- a/src/lib_c/x86_64-windows-gnu/c/string.cr
+++ b/src/lib_c/x86_64-windows-gnu/c/string.cr
@@ -1,6 +1,7 @@
 require "./stddef"
 
 lib LibC
+  fun memchr(x0 : Void*, c : Int, n : SizeT) : Void*
   fun memcmp(s1 : Void*, s2 : Void*, n : SizeT) : Int
   fun strcmp(s1 : Char*, s2 : Char*) : Int
   fun strlen(s : Char*) : SizeT


### PR DESCRIPTION
Allow the following program to work.
```
puts 3.4
```

Very minimal but came along the long way while trying to make "spec" run.

It there any preferred source of documentation for api or _if it works_ we are fine?

Should we define a #TODO to highlight `if flag?(:windows)` to be removed?

---

I needed to change branch name and github decided to close #2.