### PR TITLE
use timezone information of current time.

### DIFF
--- a/src/lib_windows.cr
+++ b/src/lib_windows.cr
@@ -122,6 +122,10 @@ lib LibWindows
     daylight_bias : Long
   end
 
+  TIME_ZONE_ID_UNKNOWN  = 0u32
+  TIME_ZONE_ID_STANDARD = 1u32
+  TIME_ZONE_ID_DAYLIGHT = 2u32
+
   struct FileTime
     low_date_time : DWord
     high_date_time : DWord

--- a/src/time.cr
+++ b/src/time.cr
@@ -605,18 +605,27 @@ struct Time
     {% end %}
 
     unless offset
-      {% if !flag?(:windows) %}
-        # current TZ may have DST, either in past, present or future
-        ret = LibC.localtime_r(pointerof(second), out tm)
-        raise Errno.new("localtime_r") if ret.null?
-        offset = tm.tm_gmtoff.to_i64
-      {% else %}
-        # TODO handle daylight?
+      {% if flag?(:windows) %}
+        # NOTE the `second` param is always the returned value
+        # of `compute_second_and_tenth_microsecond`, which means is the current time.
+        # Using GetTimeZoneInformation is sound since it returns TZ info of the current time.
         # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724421(v=vs.85).aspx
         ret = LibWindows.get_time_zone_information(out tz)
         raise WinError.new("GetTimeZoneInformation") if ret == -1
         # UTC = local time + bias
-        return tz.bias.to_i64 * - Span::TicksPerMinute
+        return (case ret
+                when LibWindows::TIME_ZONE_ID_STANDARD
+                  tz.standard_bias
+                when LibWindows::TIME_ZONE_ID_DAYLIGHT
+                  tz.daylight_bias
+                else
+                  0i64
+                end.to_i64 + tz.bias.to_i64) * - Span::TicksPerMinute
+      {% else %}
+        # current TZ may have DST, either in past, present or future
+        ret = LibC.localtime_r(pointerof(second), out tm)
+        raise Errno.new("localtime_r") if ret.null?
+        offset = tm.tm_gmtoff.to_i64
       {% end %}
     end
 


### PR DESCRIPTION
change order of conditions: specific first. general later.

@ysbaddaden if you want to review this. I made some more testing to ensure that the behavior is the same in linux and in windows regarding daylight.

I found suspicious some analysis regarding `private def self.compute_offset(second)`. I added a note in the code.

if nobody suspects I think we are good to merge.